### PR TITLE
Insufficent permissions Hatası

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -16,7 +16,7 @@ class PurchaseRequest extends AbstractRequest {
 
     protected $endpoint = '';
     protected $endpoints = [
-        'test' => 'https://testvpos.asseco-see.com.tr/fim/api',
+        'test' => 'https://entegrasyon.asseco-see.com.tr/fim/api',
         'asseco' => 'https://entegrasyon.asseco-see.com.tr/fim/api',
         'isbank' => 'spos.isbank.com.tr',
         'akbank' => 'www.sanalakpos.com',


### PR DESCRIPTION
$endpoints test testvpos olarak çalışmıyor Insufficent permissions hatası veriyor. entegrasyon olarak kullanıldığında sorun kalmıyor. güncellemesi yapıldı. (Ziraat Bankası)